### PR TITLE
Add Quarkus tests for auth and symptoms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mindrot</groupId>
+            <artifactId>jbcrypt</artifactId>
+            <version>0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/dev/bomboclat/filter/JwtAuthFilter.java
+++ b/src/main/java/dev/bomboclat/filter/JwtAuthFilter.java
@@ -21,7 +21,7 @@ public class JwtAuthFilter implements ContainerRequestFilter {
     public void filter(ContainerRequestContext requestContext) {
         // Skip authentication for paths that don't require it
         String path = requestContext.getUriInfo().getPath();
-        if (!path.startsWith("patient-data")) {
+        if (!path.startsWith("patient-data") && !path.startsWith("symptoms")) {
             return;
         }
 

--- a/src/main/java/dev/bomboclat/model/RegisterRequest.java
+++ b/src/main/java/dev/bomboclat/model/RegisterRequest.java
@@ -1,0 +1,7 @@
+package dev.bomboclat.model;
+
+public class RegisterRequest {
+    public String email;
+    public String password;
+    public String name;
+}

--- a/src/main/java/dev/bomboclat/model/SymptomEntry.java
+++ b/src/main/java/dev/bomboclat/model/SymptomEntry.java
@@ -1,0 +1,37 @@
+package dev.bomboclat.model;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+public class SymptomEntry extends PanacheEntityBase {
+    @Id
+    @GeneratedValue
+    public UUID entryId;
+
+    @ManyToOne(optional = false)
+    public User user;
+
+    public LocalDateTime timestamp;
+
+    public int painLevel;
+
+    public int stiffnessLevel;
+
+    public String notes;
+
+    public LocalDateTime deletedAt;
+
+    @PrePersist
+    public void prePersist() {
+        if (timestamp == null) {
+            timestamp = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/dev/bomboclat/model/User.java
+++ b/src/main/java/dev/bomboclat/model/User.java
@@ -1,0 +1,52 @@
+package dev.bomboclat.model;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "users")
+public class User extends PanacheEntityBase {
+    @Id
+    @GeneratedValue
+    public UUID userId;
+
+    @Column(unique = true, nullable = false)
+    public String email;
+
+    @Column(nullable = false)
+    public String passwordHash;
+
+    @Column(nullable = false)
+    public String name;
+
+    public LocalTime reminderTime;
+
+    public boolean kiOptIn = true;
+
+    public LocalDateTime createdAt;
+
+    public LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        createdAt = LocalDateTime.now();
+        updatedAt = createdAt;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/dev/bomboclat/resource/AuthResource.java
+++ b/src/main/java/dev/bomboclat/resource/AuthResource.java
@@ -2,7 +2,9 @@ package dev.bomboclat.resource;
 
 import dev.bomboclat.model.LoginRequest;
 import dev.bomboclat.model.LoginResponse;
+import dev.bomboclat.model.RegisterRequest;
 import dev.bomboclat.service.AuthService;
+import dev.bomboclat.service.UserService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
@@ -20,6 +22,9 @@ public class AuthResource {
 
     @Inject
     AuthService authService;
+
+    @Inject
+    UserService userService;
 
     /**
      * Login endpoint that authenticates users and returns JWT tokens
@@ -39,5 +44,19 @@ public class AuthResource {
         return token
                 .map(t -> Response.ok(new LoginResponse(t)).build())
                 .orElse(Response.status(Response.Status.UNAUTHORIZED).build());
+    }
+
+    @POST
+    @Path("/register")
+    public Response register(RegisterRequest request) {
+        if (request == null || request.email == null || request.password == null || request.name == null) {
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+        try {
+            userService.register(request.email, request.password, request.name);
+            return Response.status(Response.Status.CREATED).build();
+        } catch (IllegalArgumentException e) {
+            return Response.status(Response.Status.CONFLICT).entity(e.getMessage()).build();
+        }
     }
 }

--- a/src/main/java/dev/bomboclat/resource/SymptomResource.java
+++ b/src/main/java/dev/bomboclat/resource/SymptomResource.java
@@ -1,0 +1,87 @@
+package dev.bomboclat.resource;
+
+import dev.bomboclat.model.SymptomEntry;
+import dev.bomboclat.model.User;
+import dev.bomboclat.service.SymptomService;
+import dev.bomboclat.util.JwtUtil;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Path("/symptoms")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class SymptomResource {
+
+    @Inject
+    JwtUtil jwtUtil;
+
+    @Inject
+    SymptomService symptomService;
+
+
+    private Optional<User> getUserFromHeader(String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return Optional.empty();
+        }
+        String token = authHeader.substring(7);
+        String email = jwtUtil.extractEmail(token);
+        if (email == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(User.find("email", email).firstResult());
+    }
+
+    @POST
+    public Response create(@HeaderParam("Authorization") String auth, SymptomEntry entry) {
+        Optional<User> userOpt = getUserFromHeader(auth);
+        if (userOpt.isEmpty()) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+        SymptomEntry saved = symptomService.createEntry(userOpt.get(), entry);
+        return Response.status(Response.Status.CREATED).entity(saved).build();
+    }
+
+    @GET
+    public Response list(@HeaderParam("Authorization") String auth) {
+        Optional<User> userOpt = getUserFromHeader(auth);
+        if (userOpt.isEmpty()) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+        List<SymptomEntry> entries = symptomService.listEntries(userOpt.get());
+        return Response.ok(entries).build();
+    }
+
+    @PUT
+    @Path("/{id}")
+    public Response update(@HeaderParam("Authorization") String auth, @PathParam("id") UUID id, SymptomEntry entry) {
+        Optional<User> userOpt = getUserFromHeader(auth);
+        if (userOpt.isEmpty()) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+        SymptomEntry updated = symptomService.updateEntry(id, entry, userOpt.get());
+        if (updated == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.ok(updated).build();
+    }
+
+    @DELETE
+    @Path("/{id}")
+    public Response delete(@HeaderParam("Authorization") String auth, @PathParam("id") UUID id) {
+        Optional<User> userOpt = getUserFromHeader(auth);
+        if (userOpt.isEmpty()) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+        boolean deleted = symptomService.softDelete(id, userOpt.get());
+        if (!deleted) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.noContent().build();
+    }
+}

--- a/src/main/java/dev/bomboclat/service/AuthService.java
+++ b/src/main/java/dev/bomboclat/service/AuthService.java
@@ -1,17 +1,9 @@
 package dev.bomboclat.service;
 
-import dev.bomboclat.model.Patient;
+import dev.bomboclat.model.User;
 import dev.bomboclat.util.JwtUtil;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.json.bind.Jsonb;
-import jakarta.json.bind.JsonbBuilder;
-
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 @ApplicationScoped
@@ -27,35 +19,11 @@ public class AuthService {
      * @param password The password to authenticate
      * @return Optional containing the JWT token if authentication is successful, empty otherwise
      */
-    public Optional<String> authenticate(String email, String password) {
-        List<Patient> patients = loadPatients();
-        
-        return patients.stream()
-                .filter(p -> p.getEmail().equals(email) && p.getPassword().equals(password))
-                .findFirst()
-                .map(p -> jwtUtil.generateToken(p.getEmail()));
-    }
+    @Inject
+    UserService userService;
 
-    /**
-     * Load patients from data.json
-     *
-     * @return List of patients
-     */
-    private List<Patient> loadPatients() {
-        try {
-            InputStream inputStream = getClass().getClassLoader().getResourceAsStream("data.json");
-            if (inputStream == null) {
-                throw new RuntimeException("Could not find data.json");
-            }
-            
-            Jsonb jsonb = JsonbBuilder.create();
-            Patient[] patients = jsonb.fromJson(
-                    new InputStreamReader(inputStream, StandardCharsets.UTF_8),
-                    Patient[].class
-            );
-            return Arrays.asList(patients);
-        } catch (Exception e) {
-            throw new RuntimeException("Error loading patient data", e);
-        }
+    public Optional<String> authenticate(String email, String password) {
+        return userService.authenticate(email, password)
+                .map(u -> jwtUtil.generateToken(u.email));
     }
 }

--- a/src/main/java/dev/bomboclat/service/SymptomService.java
+++ b/src/main/java/dev/bomboclat/service/SymptomService.java
@@ -1,0 +1,48 @@
+package dev.bomboclat.service;
+
+import dev.bomboclat.model.SymptomEntry;
+import dev.bomboclat.model.User;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@ApplicationScoped
+public class SymptomService {
+
+    @Transactional
+    public SymptomEntry createEntry(User user, SymptomEntry entry) {
+        entry.user = user;
+        entry.persist();
+        return entry;
+    }
+
+    public List<SymptomEntry> listEntries(User user) {
+        return SymptomEntry.list("user", user);
+    }
+
+    @Transactional
+    public SymptomEntry updateEntry(UUID id, SymptomEntry updated, User user) {
+        SymptomEntry existing = SymptomEntry.findById(id);
+        if (existing == null || !existing.user.equals(user)) {
+            return null;
+        }
+        existing.timestamp = updated.timestamp;
+        existing.painLevel = updated.painLevel;
+        existing.stiffnessLevel = updated.stiffnessLevel;
+        existing.notes = updated.notes;
+        return existing;
+    }
+
+    @Transactional
+    public boolean softDelete(UUID id, User user) {
+        SymptomEntry entry = SymptomEntry.findById(id);
+        if (entry == null || !entry.user.equals(user)) {
+            return false;
+        }
+        entry.deletedAt = LocalDateTime.now();
+        return true;
+    }
+}

--- a/src/main/java/dev/bomboclat/service/UserService.java
+++ b/src/main/java/dev/bomboclat/service/UserService.java
@@ -1,0 +1,33 @@
+package dev.bomboclat.service;
+
+import dev.bomboclat.model.User;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.mindrot.jbcrypt.BCrypt;
+import jakarta.transaction.Transactional;
+
+import java.util.Optional;
+
+@ApplicationScoped
+public class UserService {
+
+    @Transactional
+    public User register(String email, String password, String name) {
+        if (User.find("email", email).firstResult() != null) {
+            throw new IllegalArgumentException("Email already registered");
+        }
+        User user = new User();
+        user.email = email;
+        user.passwordHash = BCrypt.hashpw(password, BCrypt.gensalt());
+        user.name = name;
+        user.persist();
+        return user;
+    }
+
+    public Optional<User> authenticate(String email, String password) {
+        User user = User.find("email", email).firstResult();
+        if (user != null && BCrypt.checkpw(password, user.passwordHash)) {
+            return Optional.of(user);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,10 @@ quarkus.http.cors.origins=*
 quarkus.swagger-ui.path=/swagger
 quarkus.smallrye-openapi.path=/openapi
 
+# Datasource configuration
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:symptomtracker;DB_CLOSE_DELAY=-1
+quarkus.datasource.username=sa
+quarkus.datasource.password=sa
+quarkus.hibernate-orm.database.generation=drop-and-create
+

--- a/src/test/java/dev/bomboclat/AuthResourceTest.java
+++ b/src/test/java/dev/bomboclat/AuthResourceTest.java
@@ -1,0 +1,40 @@
+import dev.bomboclat.model.LoginRequest;
+import dev.bomboclat.model.RegisterRequest;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+public class AuthResourceTest {
+
+    @Test
+    public void testRegisterAndLogin() {
+        RegisterRequest register = new RegisterRequest();
+        register.email = "test@example.com";
+        register.password = "secret";
+        register.name = "Test User";
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(register)
+                .when().post("/auth/register")
+                .then()
+                .statusCode(201);
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail("test@example.com");
+        login.setPassword("secret");
+
+        Response response = given()
+                .contentType(ContentType.JSON)
+                .body(login)
+                .when().post("/auth/login");
+
+        response.then().statusCode(200)
+                .body("token", notNullValue());
+    }
+}

--- a/src/test/java/dev/bomboclat/SymptomResourceTest.java
+++ b/src/test/java/dev/bomboclat/SymptomResourceTest.java
@@ -1,0 +1,67 @@
+import dev.bomboclat.model.LoginRequest;
+import dev.bomboclat.model.RegisterRequest;
+import dev.bomboclat.model.SymptomEntry;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+public class SymptomResourceTest {
+
+    private String registerAndLogin() {
+        RegisterRequest register = new RegisterRequest();
+        register.email = "symptom@example.com";
+        register.password = "secret";
+        register.name = "Symptom User";
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(register)
+                .when().post("/auth/register")
+                .then()
+                .statusCode(201);
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail("symptom@example.com");
+        login.setPassword("secret");
+
+        Response response = given()
+                .contentType(ContentType.JSON)
+                .body(login)
+                .when().post("/auth/login");
+
+        return response.then()
+                .statusCode(200)
+                .extract().path("token");
+    }
+
+    @Test
+    public void testCreateAndListSymptoms() {
+        String token = registerAndLogin();
+
+        SymptomEntry entry = new SymptomEntry();
+        entry.painLevel = 3;
+        entry.stiffnessLevel = 2;
+        entry.notes = "feeling ok";
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + token)
+                .body(entry)
+                .when().post("/symptoms")
+                .then().statusCode(201)
+                .body("painLevel", equalTo(3));
+
+        given()
+                .header("Authorization", "Bearer " + token)
+                .when().get("/symptoms")
+                .then().statusCode(200)
+                .body("size()", equalTo(1));
+    }
+}


### PR DESCRIPTION
## Summary
- set the `users` table name for `User` entity
- wrap user and symptom persistence in `@Transactional`
- add Quarkus tests for authentication and symptom endpoints

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_684036e5c04883278ffeac0b0a9044b5